### PR TITLE
Update documentation to work with new elixir releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Client for the Retro tool
 ## Run it locally
 
     docker-compose up
-    docker-compose exec api mix ecto.migrate
+    docker-compose run api migrate
     yarn && yarn generateTypes && yarn start


### PR DESCRIPTION
After https://github.com/retro-tool/retro-tool-api/pull/11 is merged, the old command won't work.