### PR TITLE
Add sentry integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@apollo/react-hooks": "^3.1.3",
     "@reach/dialog": "0.2.8",
     "@reach/router": "1.2.1",
+    "@sentry/browser": "^5.15.5",
     "@styled-system/theme-get": "^5.1.2",
     "apollo-boost": "^0.4.4",
     "apollo-link": "^1.2.13",

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -1,0 +1,27 @@
+type EnvConfig = {
+  readonly sentry: {
+    dsn: string;
+  };
+};
+
+type Config = {
+  readonly development: EnvConfig;
+  readonly production: EnvConfig;
+};
+
+const config: Config = {
+  development: {
+    sentry: {
+      dsn: ""
+    }
+  },
+  production: {
+    sentry: {
+      dsn:
+        "https://a4537e18a1014f908068985f7dc12609@o391523.ingest.sentry.io/5240240"
+    }
+  }
+};
+
+export const getConfig = (): EnvConfig =>
+  config[process.env.NODE_ENV] || config.development;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
+import * as Sentry from "@sentry/browser";
+import { getConfig } from "./config";
+
+const config = getConfig();
+Sentry.init(config.sentry);
 
 ReactDOM.render(<App />, document.getElementById("root"));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1802,6 +1802,58 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sentry/browser@^5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.15.5.tgz#d9a51f1388581067b50d30ed9b1aed2cbb333a36"
+  integrity sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==
+  dependencies:
+    "@sentry/core" "5.15.5"
+    "@sentry/types" "5.15.5"
+    "@sentry/utils" "5.15.5"
+    tslib "^1.9.3"
+
+"@sentry/core@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.15.5.tgz#40ea79bff5272d3fbbeeb4a98cdc59e1adbd2c92"
+  integrity sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==
+  dependencies:
+    "@sentry/hub" "5.15.5"
+    "@sentry/minimal" "5.15.5"
+    "@sentry/types" "5.15.5"
+    "@sentry/utils" "5.15.5"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.15.5.tgz#f5abbcdbe656a70e2ff02c02a5a4cffa0f125935"
+  integrity sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==
+  dependencies:
+    "@sentry/types" "5.15.5"
+    "@sentry/utils" "5.15.5"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.15.5.tgz#a0e4e071f01d9c4d808094ae7203f6c4cca9348a"
+  integrity sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==
+  dependencies:
+    "@sentry/hub" "5.15.5"
+    "@sentry/types" "5.15.5"
+    tslib "^1.9.3"
+
+"@sentry/types@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.15.5.tgz#16c97e464cf09bbd1d2e8ce90d130e781709076e"
+  integrity sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw==
+
+"@sentry/utils@5.15.5":
+  version "5.15.5"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.15.5.tgz#dec1d4c79037c4da08b386f5d34409234dcbfb15"
+  integrity sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==
+  dependencies:
+    "@sentry/types" "5.15.5"
+    tslib "^1.9.3"
+
 "@styled-system/background@^5.1.2":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@styled-system/background/-/background-5.1.2.tgz#75c63d06b497ab372b70186c0bf608d62847a2ba"


### PR DESCRIPTION
Closes https://github.com/retro-tool/retro-tool/issues/22

I'm not entirely sure if this is the best way to add configuration, but it's typed, encapsulated and it looks safe to me.

I've changed the configuration in Sentry so that we can only report from the `retrotool.app` domain, so this won't report when running locally even if you add the correct dsn. However, I did test it before that restriction and you can see an example error [here](https://sentry.io/organizations/retrotool/issues/1665912358/?project=5240240&query=&statsPeriod=14d).