### PR TITLE
Build docker image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,18 @@ jobs:
           MIX_ENV: test
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-dependency-cache-{{ checksum "yarn.lock" }}
+            - v1-dependency-cache
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run: dockerize -wait tcp://localhost:4000 -timeout 1m
       - run: yarn
       - run: yarn test --passWithNoTests
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
 
   build:
     working_directory: /app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,28 @@
 version: 2.1
+
+orbs:
+  slack: circleci/slack@3.4.2
+
+workflows:
+  version: 2
+
+  test-and-build:
+    jobs:
+      - test
+      - build:
+          context: docker-login
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master
+      - notify_build:
+          requires:
+            - build
+
 jobs:
-  build:
+  test:
     working_directory: ~/app
     docker:
       - image: circleci/node:13
@@ -26,3 +48,29 @@ jobs:
       - run: dockerize -wait tcp://localhost:4000 -timeout 1m
       - run: yarn
       - run: yarn test --passWithNoTests
+
+  build:
+    working_directory: /app
+    docker:
+      - image: docker:17.05.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: docker build -t retrotool/client:$CIRCLE_SHA1 -t retrotool/client:latest .
+      - run:
+          name: Login to DockerHub
+          command: docker login -u="$DOCKER_USER" -p="$DOCKER_PASSWORD"
+      - run:
+          name: Push commit image to DockerHub
+          command: docker push retrotool/client:$CIRCLE_SHA1
+      - run:
+          name: Push latest image to DockerHub
+          command: docker push retrotool/client:latest
+  notify_build:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - slack/notify:
+          message: ":rocket: Docker image built -> retrotool/client:latest"


### PR DESCRIPTION
With this change, we will build and push docker images when pushing to master. This way we can simplify the deployment on the production server, and have better notifications and tracing when building fails.

When an image is built and pushed, a notification is sent to the `#circle-ci` channel on slack.

I set it to only run on `master`, but before that I tried it on this branch, you can see a sample workflow [here](https://app.circleci.com/pipelines/github/retro-tool/retro-tool-client/38/workflows/b9d73df7-bb13-4b9a-94a3-83bbabc67348).

I also added caching for `node_modules` when running tests, so now the build is a lot faster 🚀 
